### PR TITLE
Presigned-URL support (url_for) + honor path prefix in standard flow (#7)

### DIFF
--- a/s3dol/base.py
+++ b/s3dol/base.py
@@ -146,6 +146,30 @@ class BaseS3BucketReader(dol.base.KvReader):
         except ClientError:
             return False
 
+    def url_for(
+        self,
+        k: str,
+        *,
+        expires_in: int = 3600,
+        client_method: str = "get_object",
+        **params,
+    ) -> str:
+        """Presigned URL for key ``k`` (default: a GET valid for ``expires_in``
+        seconds).
+
+        Lets a caller 302-redirect to the object store so it serves the bytes
+        (and HTTP ``Range``) directly, instead of proxy-streaming every byte
+        through the app. Works for any S3-compatible endpoint (AWS, R2, MinIO,
+        Supabase) — a pure client call, no object fetch. Extra ``params`` merge
+        into the presign ``Params`` (e.g. ``ResponseContentType='video/mp4'``).
+        See issue #7.
+        """
+        return self.client.generate_presigned_url(
+            client_method,
+            Params={"Bucket": self.bucket_name, "Key": k, **params},
+            ExpiresIn=expires_in,
+        )
+
 
 class BaseS3BucketDol(BaseS3BucketReader, dol.base.KvPersister):
     skip_bucket_exists_check: bool = False
@@ -194,6 +218,11 @@ class S3BucketReader(BaseS3BucketReader):
     def __contains__(self, k) -> bool:
         _id = self._id_of_key(k)
         return super().__contains__(_id)
+
+    def url_for(self, k: str, **kwargs) -> str:
+        """Prefix-aware presigned URL: maps ``k`` through ``_id_of_key`` (as
+        ``__getitem__`` does) so the URL points at the same object."""
+        return super().url_for(self._id_of_key(k), **kwargs)
 
 
 class S3BucketDol(S3BucketReader, BaseS3BucketDol):

--- a/s3dol/store.py
+++ b/s3dol/store.py
@@ -83,6 +83,13 @@ def S3Store(
     elif make_bucket is True and bucket_name not in s3cr:
         s3cr[bucket_name] = {}
 
+    if path:
+        # Apply the key prefix in the standard flow too. It was documented
+        # (":param path: prefix to use for bucket keys") but silently dropped
+        # here — only the Supabase / skip-check branches honored it. Normalize
+        # exactly as S3BucketReader.__post_init__ does. #7 follow-up.
+        bucket.prefix = f"{path.strip(bucket.delimiter)}{bucket.delimiter}"
+
     return bucket
 
 

--- a/s3dol/tests/test_url_for.py
+++ b/s3dol/tests/test_url_for.py
@@ -1,0 +1,61 @@
+"""Presigned-URL (``url_for``) tests, mocked with moto. See issue #7.
+
+Unlike the env-gated real-S3 tests, these run anywhere — moto fully mocks the
+S3 API including ``generate_presigned_url``.
+"""
+
+import pytest
+
+pytest.importorskip("moto")
+from moto import mock_aws
+
+from s3dol.store import S3Store
+
+_CREDS = dict(
+    aws_access_key_id="testing",
+    aws_secret_access_key="testing",
+    region_name="us-east-1",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_aws_env(monkeypatch):
+    """Make these moto tests hermetic. The localstack tests (test_base) set
+    ``AWS_ENDPOINT_URL=http://localhost:4566`` via ``os.environ`` with no
+    cleanup, which would route boto3 past moto to a (down) localstack. Clear any
+    leaked endpoint + pin fake creds so ``@mock_aws`` always intercepts."""
+    for var in ("AWS_ENDPOINT_URL", "AWS_ENDPOINT_URL_S3", "AWS_PROFILE"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+
+@mock_aws
+def test_url_for_returns_presigned_get_url():
+    store = S3Store("test-bucket", make_bucket=True, **_CREDS)
+    store["hello.txt"] = b"hi"
+    url = store.url_for("hello.txt")
+    assert isinstance(url, str)
+    assert "test-bucket" in url
+    assert "hello.txt" in url
+    # Presigned marker (SigV4 X-Amz-Signature / SigV2 Signature).
+    assert "Signature" in url
+
+
+@mock_aws
+def test_url_for_is_prefix_aware():
+    # path= sets a key prefix; url_for must point at the prefixed id, matching
+    # __getitem__ (else the URL 404s).
+    store = S3Store("test-bucket", make_bucket=True, path="blobs", **_CREDS)
+    store["abc"] = b"x"
+    url = store.url_for("abc")
+    assert "blobs" in url and "abc" in url
+
+
+@mock_aws
+def test_url_for_honors_expires_in():
+    store = S3Store("test-bucket", make_bucket=True, **_CREDS)
+    store["k"] = b"v"
+    url = store.url_for("k", expires_in=60)
+    assert "X-Amz-Expires=60" in url or "Expires=" in url


### PR DESCRIPTION
Closes #7.

## What
- **`url_for(key, *, expires_in=3600, client_method='get_object', **params)`** on the S3 bucket stores — returns a presigned URL via the boto3 client (prefix-aware override on `S3BucketReader`). Lets a caller **302-redirect** so the object store serves bytes + HTTP `Range` directly, off the app process. Works for any S3-compatible endpoint (AWS / R2 / MinIO / Supabase) — pure client call, no object fetch.
- **Bug fix:** `S3Store(path=...)` (documented as the key prefix) was silently **dropped in the standard AWS flow** — only the Supabase / skip-check branches honored it. Now applied there too.
- **Tests:** `test_url_for.py`, moto-based so they run anywhere (no real S3). An autouse fixture clears `AWS_ENDPOINT_URL` because `test_base` sets it (localstack) via `os.environ` without cleanup, leaking across the suite.

## First customer
lacing's `ArtifactStore.blob_location` (reelee storage migration → S3, reelee#134): it probes the blob backend for `url_for` and 302-redirects when present.

## Note
The `localstack`-parametrized tests in `test_base`/`test_store` fail without a running localstack server (pre-existing/environmental). Making them skip-when-unreachable + use `monkeypatch` for env is a separate test-hygiene follow-up.

https://claude.ai/code/session_01NLg6gmcHzRiDviqdgyooZk